### PR TITLE
Créateur MBTiles : relief 3D hors-ligne (MNT) fusionné dans le même fichier

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -279,10 +279,12 @@ Interface Mode 3 (carte Leaflet + contrôles + barre de progression).
 - `updateCreatorUI()` — barre de progression + alertes (seuil **8000 tuiles** RAM, **100 000** avec OPFS)
 - `checkOPFS()` — détecte le support du stockage privé navigateur
 - `seedTiles(selectedBbox, selectedZoom)` — orchestre via `seedManager.js`
-- Case « Inclure le relief 3D hors-ligne (MNT) » : génère en plus un MBTiles séparé
-  `<nom>_MNT.mbtiles` (tuiles PNG Terrarium/AWS, zoom 0-12, passthrough sans
-  recompression) — exploitable comme source `raster-dem` par des applications
-  tierces (ex. CadoTour, vue 3D) sans connexion.
+- Case « Inclure le relief 3D hors-ligne (MNT) » : ajoute les tuiles PNG Terrarium/AWS
+  du MNT (passthrough sans recompression) au niveau de zoom 12 dans le MÊME
+  MBTiles que le fond de carte. Ce niveau est alors réservé (zooms 0-12 grisés
+  pour le fond, qui démarre au zoom 13) — une métadonnée `mnt_zoom` signale la
+  convention aux lecteurs qui la connaissent (ex. CadoTour, source `raster-dem`
+  en vue 3D, tuiles de fond ignorées à ce niveau en vue 2D).
 
 **Spécifique** : gestion projection EPSG:3395 pour Yandex (correction nécessaire), gestion QuadKey pour Bing.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -279,6 +279,10 @@ Interface Mode 3 (carte Leaflet + contrôles + barre de progression).
 - `updateCreatorUI()` — barre de progression + alertes (seuil **8000 tuiles** RAM, **100 000** avec OPFS)
 - `checkOPFS()` — détecte le support du stockage privé navigateur
 - `seedTiles(selectedBbox, selectedZoom)` — orchestre via `seedManager.js`
+- Case « Inclure le relief 3D hors-ligne (MNT) » : génère en plus un MBTiles séparé
+  `<nom>_MNT.mbtiles` (tuiles PNG Terrarium/AWS, zoom 0-12, passthrough sans
+  recompression) — exploitable comme source `raster-dem` par des applications
+  tierces (ex. CadoTour, vue 3D) sans connexion.
 
 **Spécifique** : gestion projection EPSG:3395 pour Yandex (correction nécessaire), gestion QuadKey pour Bing.
 

--- a/help.html
+++ b/help.html
@@ -213,6 +213,14 @@
                 Une carte numérique est composée de "tuiles". Plus vous zoomez, plus il y a de tuiles.
                 <br><strong>Attention :</strong> Cocher les zooms élevés (17, 18, 19) sur une grande zone peut générer des millions de tuiles.
             </p>
+
+            <h3 class="text-xl font-semibold mb-3 text-gray-900 dark:text-white">Relief 3D hors-ligne (MNT)</h3>
+            <p class="text-sm mb-4">
+                La case <strong>« Inclure le relief 3D hors-ligne »</strong> génère, en plus du fond de carte, un
+                second fichier <code>_MNT.mbtiles</code> contenant le modèle numérique de terrain (altitudes) de la
+                zone. Il permet à des applications compatibles (comme CadoTour, en vue 3D) d'afficher le relief
+                sans connexion internet.
+            </p>
         </section>
 
         <section id="m4-jobs" class="mb-12">

--- a/help.html
+++ b/help.html
@@ -216,10 +216,11 @@
 
             <h3 class="text-xl font-semibold mb-3 text-gray-900 dark:text-white">Relief 3D hors-ligne (MNT)</h3>
             <p class="text-sm mb-4">
-                La case <strong>« Inclure le relief 3D hors-ligne »</strong> génère, en plus du fond de carte, un
-                second fichier <code>_MNT.mbtiles</code> contenant le modèle numérique de terrain (altitudes) de la
-                zone. Il permet à des applications compatibles (comme CadoTour, en vue 3D) d'afficher le relief
-                sans connexion internet.
+                La case <strong>« Inclure le relief 3D hors-ligne »</strong> ajoute, dans le même fichier MBTiles,
+                le modèle numérique de terrain (altitudes) au niveau de zoom 12. Cocher cette case réserve ce
+                niveau au relief : les zooms 0 à 12 sont grisés pour le fond de carte, qui démarre alors au
+                zoom 13. Ce fichier unique permet à des applications compatibles (comme CadoTour, en vue 3D)
+                d'afficher à la fois le fond de carte et le relief sans connexion internet.
             </p>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -845,8 +845,10 @@
                             <input type="checkbox" id="creator-include-mnt" class="mt-1">
                             <label for="creator-include-mnt" class="text-sm text-gray-700 dark:text-gray-300">
                                 <span class="font-bold">Inclure le relief 3D hors-ligne (MNT)</span> —
-                                génère en plus un second fichier <code>_MNT.mbtiles</code> (modèle numérique de
-                                terrain, zoom 0-12) exploitable par la vue 3D de CadoTour sans connexion.
+                                ajoute dans le même MBTiles les tuiles d'altitude du niveau de zoom 12,
+                                exploitables par la vue 3D de CadoTour sans connexion. Les niveaux de zoom
+                                0 à 12 sont alors réservés au relief et désactivés ci-dessous : le fond de
+                                carte est téléchargé à partir du zoom 13.
                             </label>
                         </div>
 

--- a/index.html
+++ b/index.html
@@ -840,6 +840,16 @@
                             </div>
                         </div>
 
+                        <!-- Relief 3D (MNT) hors-ligne -->
+                        <div class="mt-4 flex items-start gap-2">
+                            <input type="checkbox" id="creator-include-mnt" class="mt-1">
+                            <label for="creator-include-mnt" class="text-sm text-gray-700 dark:text-gray-300">
+                                <span class="font-bold">Inclure le relief 3D hors-ligne (MNT)</span> —
+                                génère en plus un second fichier <code>_MNT.mbtiles</code> (modèle numérique de
+                                terrain, zoom 0-12) exploitable par la vue 3D de CadoTour sans connexion.
+                            </label>
+                        </div>
+
                         <div class="mt-6 text-center">
                             <button id="creator-start-btn" class="btn-main btn-grid w-full md:w-1/2" disabled>
                                 Lancer la création du MBTiles

--- a/mbtilesCreator.js
+++ b/mbtilesCreator.js
@@ -27,6 +27,21 @@ const TILE_QUALITY = 0.92;            // 0..1, ignoré si TILE_FORMAT === 'image
                                       // rester au plus près de l'ortho d'origine
 const TILE_BG      = '#ffffff';       // fond pour les zones transparentes (JPEG only)
 
+// Relief 3D hors-ligne (MNT) — source mondiale "Terrarium" (Mapzen/AWS Open Data
+// Terrain Tiles), la même que celle utilisée en ligne par la vue 3D de CadoTour
+// (map3d.js : DEM_URL / DEM_MAXZOOM = 12 — la donnée source est ~30 m (SRTM),
+// au-delà MapLibre sur-échantillonne lui-même le dernier niveau natif).
+// Généré comme un MBTiles séparé (mono-couche → passthrough, cf. TILE_FORMAT
+// ci-dessus) : l'encodage RVB de l'altitude ne doit jamais être recompressé.
+const MNT_TILE_URL = 'https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png';
+const MNT_MAX_ZOOM = 12;
+const MNT_LAYER_CONFIG = {
+    id: 'mnt_terrarium',
+    name: 'Relief (MNT Terrarium)',
+    maxZoom: MNT_MAX_ZOOM,
+    layers: [{ url: MNT_TILE_URL, type: 'xyz' }]
+};
+
 // Détection OPFS (Origin Private File System) — pas besoin de SharedArrayBuffer
 let _opfsAvailable = null;
 async function checkOPFS() {
@@ -793,6 +808,14 @@ function startMbtilesJob() {
     const job = new MbtilesJob(jobIdCounter++, currentCreatorBounds, zooms, layerConfig, filename);
     activeJobs.push(job);
     job.start();
+
+    if (document.getElementById('creator-include-mnt')?.checked) {
+        const mntZooms = [];
+        for (let z = 0; z <= MNT_MAX_ZOOM; z++) mntZooms.push(z);
+        const mntJob = new MbtilesJob(jobIdCounter++, currentCreatorBounds, mntZooms, MNT_LAYER_CONFIG, `${filename}_MNT`);
+        activeJobs.push(mntJob);
+        mntJob.start();
+    }
 }
 
 function setupCreatorAddressSearch() {

--- a/mbtilesCreator.js
+++ b/mbtilesCreator.js
@@ -31,16 +31,19 @@ const TILE_BG      = '#ffffff';       // fond pour les zones transparentes (JPEG
 // Terrain Tiles), la même que celle utilisée en ligne par la vue 3D de CadoTour
 // (map3d.js : DEM_URL / DEM_MAXZOOM = 12 — la donnée source est ~30 m (SRTM),
 // au-delà MapLibre sur-échantillonne lui-même le dernier niveau natif).
-// Généré comme un MBTiles séparé (mono-couche → passthrough, cf. TILE_FORMAT
-// ci-dessus) : l'encodage RVB de l'altitude ne doit jamais être recompressé.
+//
+// Le MNT est écrit dans le MÊME MBTiles que le fond de carte, sur le seul
+// niveau de zoom 12, réservé à cet usage : quand l'option est cochée, les
+// niveaux 0-12 sont interdits pour le fond (grisés dans le sélecteur) — le
+// fond est alors téléchargé à partir du zoom 13. Le zoom 12 ne collisionne
+// donc jamais avec une vraie tuile de fond dans la table `tiles` (même clé
+// zoom/x/y). Une métadonnée `mnt_zoom` signale la convention aux lecteurs qui
+// la connaissent (CadoTour) pour qu'ils excluent ce niveau du rendu 2D et
+// l'utilisent comme source `raster-dem` pour la vue 3D.
+// Toujours en passthrough (pas de recompression) : l'encodage RVB de
+// l'altitude ne doit jamais être altéré.
 const MNT_TILE_URL = 'https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png';
-const MNT_MAX_ZOOM = 12;
-const MNT_LAYER_CONFIG = {
-    id: 'mnt_terrarium',
-    name: 'Relief (MNT Terrarium)',
-    maxZoom: MNT_MAX_ZOOM,
-    layers: [{ url: MNT_TILE_URL, type: 'xyz' }]
-};
+const MNT_ZOOM = 12; // seul niveau réservé au MNT — les niveaux < 13 sont interdits pour le fond
 
 // Détection OPFS (Origin Private File System) — pas besoin de SharedArrayBuffer
 let _opfsAvailable = null;
@@ -214,6 +217,7 @@ function initCreatorMode() {
     document.getElementById('creator-start-btn').addEventListener('click', startMbtilesJob);
     document.getElementById('creator-select-all-zooms').addEventListener('click', () => toggleZooms(true));
     document.getElementById('creator-select-none-zooms').addEventListener('click', () => toggleZooms(false));
+    document.getElementById('creator-include-mnt')?.addEventListener('change', applyMntZoomLock);
 }
 
 window.initCreatorMode = initCreatorMode;
@@ -248,6 +252,7 @@ function generateZoomCheckboxes(maxZoom) {
         div.textContent = `Z${z}`;
         div.dataset.zoom = z;
         div.onclick = function() {
+            if (this.classList.contains('mnt-locked')) return;
             this.classList.toggle('checked');
             updateCreatorUI();
         };
@@ -261,12 +266,33 @@ function generateZoomCheckboxes(maxZoom) {
             }
         }
     }
+    applyMntZoomLock();
 }
 
 function toggleZooms(state) {
     document.querySelectorAll('.zoom-checkbox-label').forEach(el => {
+        if (el.classList.contains('mnt-locked')) { el.classList.remove('checked'); return; }
         if(state) el.classList.add('checked');
         else el.classList.remove('checked');
+    });
+    updateCreatorUI();
+}
+
+// Case "Inclure le relief 3D hors-ligne" cochée : les niveaux 0-12 (réservés
+// au MNT, cf. MNT_ZOOM) sont interdits pour le fond de carte — le zoom 12 ne
+// doit jamais contenir de tuile de fond dans le MBTiles final. Ré-appliqué à
+// chaque régénération de la grille (changement de fond de carte) et à chaque
+// bascule de la case.
+function applyMntZoomLock() {
+    const locked = document.getElementById('creator-include-mnt')?.checked;
+    document.querySelectorAll('.zoom-checkbox-label').forEach(el => {
+        const z = parseInt(el.dataset.zoom, 10);
+        if (locked && z <= MNT_ZOOM) {
+            el.classList.remove('checked');
+            el.classList.add('mnt-locked');
+        } else {
+            el.classList.remove('mnt-locked');
+        }
     });
     updateCreatorUI();
 }
@@ -304,6 +330,11 @@ function updateCreatorUI() {
         const tiles = getTileRange(currentCreatorBounds, z);
         totalTiles += (tiles.xMax - tiles.xMin + 1) * (tiles.yMax - tiles.yMin + 1);
     });
+
+    if (document.getElementById('creator-include-mnt')?.checked) {
+        const mntTiles = getTileRange(currentCreatorBounds, MNT_ZOOM);
+        totalTiles += (mntTiles.xMax - mntTiles.xMin + 1) * (mntTiles.yMax - mntTiles.yMin + 1);
+    }
 
     infoTiles.textContent = totalTiles.toLocaleString() + " tuiles";
     const sizeMb = (totalTiles * TILE_SIZE_ESTIMATE_KB) / 1024;
@@ -344,12 +375,13 @@ function getTileRange(bounds, zoom) {
 // --- JOB MANAGEMENT ---
 
 class MbtilesJob {
-    constructor(id, bounds, zooms, layerConfig, filename) {
+    constructor(id, bounds, zooms, layerConfig, filename, includeMnt = false) {
         this.id = id;
         this.bounds = bounds;
         this.zooms = zooms;
         this.layerConfig = layerConfig;
         this.filename = filename;
+        this.includeMnt = includeMnt; // ajoute le MNT (zoom MNT_ZOOM) dans ce même MBTiles
         this.status = 'pending';
         this.totalTiles = 0;
         this.processedTiles = 0;
@@ -378,6 +410,10 @@ class MbtilesJob {
             const range = getTileRange(this.bounds, z);
             count += (range.xMax - range.xMin + 1) * (Math.max(range.yMin, range.yMax) - Math.min(range.yMin, range.yMax) + 1);
         });
+        if (this.includeMnt) {
+            const range = getTileRange(this.bounds, MNT_ZOOM);
+            count += (range.xMax - range.xMin + 1) * (Math.max(range.yMin, range.yMax) - Math.min(range.yMin, range.yMax) + 1);
+        }
         return count;
     }
 
@@ -388,7 +424,19 @@ class MbtilesJob {
             const yEnd = Math.max(range.yMin, range.yMax);
             for (let x = range.xMin; x <= range.xMax; x++) {
                 for (let y = yStart; y <= yEnd; y++) {
-                    yield { x, y, z };
+                    yield { x, y, z, mnt: false };
+                }
+            }
+        }
+        // MNT en dernier : le premier tuile récupérée (utilisée pour détecter le
+        // format passthrough, cf. _fetchRawTile) reste une tuile de fond.
+        if (this.includeMnt) {
+            const range = getTileRange(this.bounds, MNT_ZOOM);
+            const yStart = Math.min(range.yMin, range.yMax);
+            const yEnd = Math.max(range.yMin, range.yMax);
+            for (let x = range.xMin; x <= range.xMax; x++) {
+                for (let y = yStart; y <= yEnd; y++) {
+                    yield { x, y, z: MNT_ZOOM, mnt: true };
                 }
             }
         }
@@ -479,6 +527,10 @@ class MbtilesJob {
         this.db.run("INSERT INTO metadata VALUES (?, ?)", ["bounds", boundsStr]);
         this.db.run("INSERT INTO metadata VALUES (?, ?)", ["type", "overlay"]);
         this.db.run("INSERT INTO metadata VALUES (?, ?)", ["version", "1.2"]);
+        // Convention lue par CadoTour (tileSource.js) : ce niveau de zoom contient
+        // le MNT (Terrarium) et non une tuile de fond — à exclure du rendu 2D et
+        // à utiliser comme source raster-dem pour la vue 3D.
+        if (this.includeMnt) this.db.run("INSERT INTO metadata VALUES (?, ?)", ["mnt_zoom", String(MNT_ZOOM)]);
     }
 
     async start() {
@@ -529,6 +581,12 @@ class MbtilesJob {
 
     // Récupère une tuile → retourne le blob à stocker (ou null si vide/échec).
     async _processTile(tile) {
+        // Tuile MNT (zoom réservé) : toujours mono-source, passthrough — jamais
+        // composée avec le fond, même si celui-ci est multi-couches.
+        if (tile.mnt) {
+            return this._fetchRawTile(MNT_TILE_URL.replace('{z}', tile.z).replace('{x}', tile.x).replace('{y}', tile.y));
+        }
+
         const urls = this._tileUrls(tile);
 
         // --- Cas mono-couche : passthrough natif (AUCUNE recompression) ---
@@ -804,18 +862,11 @@ function startMbtilesJob() {
     const layerConfig = MAP_LAYERS.find(l => l.id === layerId);
     let filename = document.getElementById('creator-filename').value.trim();
     if (!filename) filename = `Carte_Offline_${Date.now()}`;
+    const includeMnt = document.getElementById('creator-include-mnt')?.checked || false;
 
-    const job = new MbtilesJob(jobIdCounter++, currentCreatorBounds, zooms, layerConfig, filename);
+    const job = new MbtilesJob(jobIdCounter++, currentCreatorBounds, zooms, layerConfig, filename, includeMnt);
     activeJobs.push(job);
     job.start();
-
-    if (document.getElementById('creator-include-mnt')?.checked) {
-        const mntZooms = [];
-        for (let z = 0; z <= MNT_MAX_ZOOM; z++) mntZooms.push(z);
-        const mntJob = new MbtilesJob(jobIdCounter++, currentCreatorBounds, mntZooms, MNT_LAYER_CONFIG, `${filename}_MNT`);
-        activeJobs.push(mntJob);
-        mntJob.start();
-    }
 }
 
 function setupCreatorAddressSearch() {

--- a/style.css
+++ b/style.css
@@ -482,6 +482,13 @@ input[type="radio"].custom-radio:checked + span {
     background-color: var(--primary-color);
     color: white;
 }
+/* Niveau réservé au MNT (relief 3D) quand la case correspondante est cochée :
+   interdit pour le fond de carte, cf. mbtilesCreator.js (MNT_ZOOM). */
+.zoom-checkbox-label.mnt-locked {
+    opacity: 0.35;
+    cursor: not-allowed;
+    text-decoration: line-through;
+}
 /* --- CSS POUR LES CONTRÔLES DÉTACHÉS (HUD) --- */
 
 /* Ligne rouge de rotation - doit être au-dessus de tout */

--- a/sw.js
+++ b/sw.js
@@ -1,8 +1,8 @@
 // sw.js - Service Worker PWA
 // ⚠ Mettre à jour CACHE_NAME à chaque déploiement pour invalider le cache existant.
 
-const CACHE_NAME = 'cado-cache-23.0';
-const SW_APP_VERSION = '23.0';
+const CACHE_NAME = 'cado-cache-23.1';
+const SW_APP_VERSION = '23.1';
 
 // Liste EXACTE des fichiers à mettre en cache.
 // Si un seul fichier manque, la PWA ne s'installera pas.

--- a/version.js
+++ b/version.js
@@ -8,7 +8,7 @@ const CHANGELOG = [
     version: '23.1',
     date: '2026-07-21',
     changes: [
-      'MBTiles Creator : nouvelle option "Inclure le relief 3D hors-ligne (MNT)" — génère en plus un fichier _MNT.mbtiles (tuiles Terrarium, zoom 0-12) exploitable comme source raster-dem par des applications tierces (ex. CadoTour) sans connexion',
+      'MBTiles Creator : nouvelle option "Inclure le relief 3D hors-ligne (MNT)" — ajoute les tuiles Terrarium au zoom 12 dans le même MBTiles que le fond de carte (zooms 0-12 réservés, fond à partir du zoom 13), exploitable comme source raster-dem par des applications tierces (ex. CadoTour) sans connexion',
     ],
   },
   {

--- a/version.js
+++ b/version.js
@@ -1,9 +1,16 @@
 // version.js
 
 // Source unique de vérité pour la version de l'application.
-const APP_VERSION = '23.0';
+const APP_VERSION = '23.1';
 
 const CHANGELOG = [
+  {
+    version: '23.1',
+    date: '2026-07-21',
+    changes: [
+      'MBTiles Creator : nouvelle option "Inclure le relief 3D hors-ligne (MNT)" — génère en plus un fichier _MNT.mbtiles (tuiles Terrarium, zoom 0-12) exploitable comme source raster-dem par des applications tierces (ex. CadoTour) sans connexion',
+    ],
+  },
   {
     version: '23.0',
     date: '2026-06-24',


### PR DESCRIPTION
## Résumé

CadoTour ne charge qu'un seul MBTiles à la fois (`tileSource.js` est un singleton) : un fichier `_MNT.mbtiles` séparé serait donc inexploitable. Le relief est écrit dans le **même fichier** que le fond de carte, sur un niveau de zoom **réservé** :

- Nouvelle option **« Inclure le relief 3D hors-ligne (MNT) »** dans le Créateur MBTiles (Mode 4).
- Quand elle est cochée, les niveaux de zoom **0 à 12 sont grisés/décochés** (verrouillés) dans le sélecteur de zoom : le fond de carte est alors téléchargé à partir du **zoom 13**. Le zoom 12 ne contient donc jamais de vraie tuile de fond — aucune collision possible sur la clé `(zoom_level, tile_column, tile_row)`.
- Le **zoom 12** est rempli avec les tuiles d'élévation **Terrarium** (Mapzen/AWS Open Data Terrain Tiles), toujours en **passthrough** (aucune recompression — l'encodage RVB de l'altitude doit rester bit-exact).
- Une métadonnée `mnt_zoom` (valeur `"12"`) est écrite dans le MBTiles pour signaler la convention à un lecteur qui la connaît (CadoTour) : exclure ce niveau du rendu 2D et l'utiliser comme source `raster-dem` pour la vue 3D.
- Le zoom 12 et le plafond `DEM_MAXZOOM` correspondent exactement à ce que `map3d.js` de CadoTour utilise déjà en ligne — la donnée source est ~30 m (SRTM), au-delà ce ne serait que de l'interpolation.

Note : côté CadoTour, une adaptation séparée reste nécessaire (`tileSource.js` doit exclure `mnt_zoom` de la pyramide 2D, `map3d.js` doit lire le MNT depuis ce MBTiles hors-ligne au lieu de l'URL AWS) — en discussion, hors périmètre de cette PR.

## Détails

- `mbtilesCreator.js` :
  - `MbtilesJob` accepte un flag `includeMnt` ; `tileGenerator()`/`computeTotalTiles()` ajoutent les tuiles MNT (zoom 12 uniquement) au job existant, taguées `{ mnt: true }` pour dispatcher vers un fetch passthrough dédié dans `_processTile()`.
  - `applyMntZoomLock()` grise/décoche les niveaux 0-12 dans le sélecteur quand la case est cochée (et respecte les boutons "Tous"/"Aucun"), ré-appliqué à chaque régénération de la grille.
  - Métadonnée `mnt_zoom` écrite dans `_initDb()` quand `includeMnt` est actif.
- `index.html` : libellé de la case à cocher mis à jour (fichier unique).
- `style.css` : style `.zoom-checkbox-label.mnt-locked` (grisé, non cliquable).
- `help.html`, `DOCUMENTATION.md`, `version.js` : documentation mise à jour.

## Test plan

- [x] `node --check` sur les fichiers JS modifiés
- [x] Test automatisé (Playwright + Chromium local, harness isolé sans dépendance réseau/Leaflet) : le verrouillage des zooms 0-12 s'active/se désactive correctement avec la case, les clics sur un niveau verrouillé sont ignorés, "Tous" respecte le verrouillage, et `MbtilesJob.tileGenerator()` génère exactement les tuiles attendues (MNT au zoom 12 uniquement, fond aux zooms sélectionnés ≥13) pour `includeMnt: true` et un comportement inchangé pour `includeMnt: false`
- [ ] Test manuel en conditions réelles : cocher l'option sur une petite zone (département) et vérifier le MBTiles généré (ex. avec `tools/mbtiles_diag.py`)

https://claude.ai/code/session_01V7E5QTmZRsniAVVgTaRMcK