### PR TITLE
Corrige la reprojection des tuiles Yandex (3395→3857) sur canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -1008,11 +1008,13 @@
         function createBaseLayers() {
             const baseMaps = {};
             // Correction de projection Yandex : EPSG:3395 (Mercator ellipsoïdal WGS84)
-            // vs EPSG:3857 (Pseudo-Mercator sphérique) utilisé par Leaflet.
-            // Approche en 2 étapes :
-            //   1. getTileUrl  → trouve la tuile EPSG:3395 qui contient le bord nord de la tuile EPSG:3857
-            //   2. createTile  → applique un décalage CSS vertical en pixels pour corriger
-            //                    le sous-alignement résiduel (~pixel-perfect)
+            // vs EPSG:3857 (Pseudo-Mercator sphérique) utilisé par Leaflet. Chaque tuile
+            // Leaflet est un <canvas> sur lequel on REPROJETTE les 1-2 tuiles Yandex
+            // couvrant exactement sa plage de latitudes (cf. createTile ci-dessous).
+            // Deux tuiles Leaflet voisines se partagent mathématiquement la même
+            // frontière 3395 → aucun jour possible entre les rangées (contrairement à
+            // l'ancien décalage CSS approché — marginTop + étirement de hauteur —
+            // qui laissait des jours horizontaux et déformait légèrement l'image).
             const e_WGS84 = 0.0818191908426215;
 
             function yMerc3395(latRad) {
@@ -1025,37 +1027,71 @@
                 return Math.atan(Math.sinh(Math.PI * (1 - 2 * yTile / n)));
             }
 
-            const L_YandexLayer = L.TileLayer.extend({
-                getTileUrl: function (coords) {
-                    const z = coords.z, x = coords.x;
-                    const n = Math.pow(2, z);
-                    // Bord nord de la tuile EPSG:3857 → tuile EPSG:3395 qui le contient
-                    const latN = lat3857(coords.y, n);
-                    const y3395 = Math.floor(n / 2 * (1 - yMerc3395(latN) / Math.PI));
-                    // Stocker les coords pour createTile
-                    this._lastCoords = { z, x, yReq: coords.y, y3395 };
-                    return L.Util.template(this._url, L.extend({}, this.options, { x, y: y3395, z }));
+            const L_YandexLayer = L.GridLayer.extend({
+                initialize: function (url, options) {
+                    this._url = url;
+                    L.GridLayer.prototype.initialize.call(this, options);
                 },
                 createTile: function (coords, done) {
-                    const tile = L.TileLayer.prototype.createTile.call(this, coords, done);
-                    const z = coords.z, n = Math.pow(2, z);
-                    const tileSize = this.getTileSize().y; // généralement 256
+                    const ts = this.getTileSize().y; // généralement 256
+                    const tile = document.createElement('canvas');
+                    tile.width = ts; tile.height = ts;
 
-                    // Bord nord EPSG:3857 de la tuile demandée par Leaflet
-                    const latN_3857 = lat3857(coords.y, n);
-                    // Tuile EPSG:3395 sélectionnée pour ce bord nord
-                    const y3395 = Math.floor(n / 2 * (1 - yMerc3395(latN_3857) / Math.PI));
-                    // Position en pixels du bord nord EPSG:3857 dans la tuile EPSG:3395
-                    const latN_3395 = lat3857(y3395 * 2 / n, n * 2 / n); // bord nord de y3395
-                    // En EPSG:3395, la latitude latN_3857 est à quelle fraction de la tuile y3395 ?
-                    const fracY = (n / 2 * (1 - yMerc3395(latN_3857) / Math.PI)) - y3395;
-                    // Décalage : la tuile doit être décalée vers le haut de fracY * tileSize pixels
-                    // marginTop sub-pixel : décalage précis pour l'alignement projection
-                    const offsetPx = -(fracY * tileSize);
-                    tile.style.marginTop = offsetPx + 'px';
-                    // Extension de hauteur pour combler le gap sous la tuile décalée.
-                    // Les pixels étirés en bas sont toujours couverts par la tuile suivante.
-                    tile.style.height = (tileSize + Math.ceil(-offsetPx) + 1) + 'px';
+                    const z = coords.z, n = Math.pow(2, z);
+                    // Plage de pixels VERTICAUX du monde EPSG:3395 (à ce zoom) couverte
+                    // par la tuile EPSG:3857 demandée : bords nord et sud convertis via
+                    // lat 3857 → ordonnée Mercator 3395. Les X sont identiques dans les
+                    // deux projections (même découpage en longitude).
+                    const py = (yTile) => n * ts / 2 * (1 - yMerc3395(lat3857(yTile, n)) / Math.PI);
+                    const pyN = py(coords.y), pyS = py(coords.y + 1);
+                    const H = pyS - pyN; // hauteur 3395 correspondante (≈ ts, pas exactement)
+
+                    // Tuiles sources 3395 couvrant [pyN, pyS) — 1 ou 2 en pratique.
+                    const ty0 = Math.max(0, Math.floor(pyN / ts));
+                    const ty1 = Math.min(n - 1, Math.floor((pyS - 1e-9) / ts));
+                    const srcs = [];
+                    for (let ty = ty0; ty <= ty1; ty++)
+                        srcs.push({ ty, url: L.Util.template(this._url, L.extend({}, this.options, { x: coords.x, y: ty, z })) });
+
+                    // Chargement en CORS d'abord (Yandex sert les en-têtes quand on les
+                    // demande) : le canvas reste « propre » et réutilisable (export,
+                    // capture…). Repli sans crossOrigin si le CORS échoue.
+                    const load = (url) => new Promise(resolve => {
+                        const img = new Image();
+                        img.crossOrigin = 'anonymous';
+                        img.onload = () => resolve(img);
+                        img.onerror = () => {
+                            const raw = new Image();
+                            raw.onload = () => resolve(raw);
+                            raw.onerror = () => resolve(null);
+                            raw.src = url;
+                        };
+                        img.src = url;
+                    });
+
+                    Promise.all(srcs.map(s => load(s.url))).then(imgs => {
+                        const ctx = tile.getContext('2d');
+                        let drawn = 0;
+                        for (let i = 0; i < srcs.length; i++) {
+                            const img = imgs[i];
+                            if (!img) continue;
+                            const ty = srcs[i].ty;
+                            // Bande de la tuile source comprise dans [pyN, pyS], remappée
+                            // linéairement sur la hauteur du canvas (la non-linéarité
+                            // 3857↔3395 sur 256 px est très en dessous du pixel).
+                            const srcTop = Math.max(pyN, ty * ts);
+                            const srcBot = Math.min(pyS, (ty + 1) * ts);
+                            const sy = srcTop - ty * ts, sh = srcBot - srcTop;
+                            const dy = (srcTop - pyN) * ts / H, dh = sh * ts / H;
+                            // +1 px de recouvrement (sauf dernière bande) : la bande
+                            // suivante, opaque, repeint par-dessus — supprime le liseré
+                            // d'anticrénelage aux frontières fractionnaires.
+                            const over = (i < srcs.length - 1) ? 1 : 0;
+                            ctx.drawImage(img, 0, sy, img.width, sh, 0, dy, ts, dh + over);
+                            drawn++;
+                        }
+                        done(drawn ? null : new Error('tuiles Yandex indisponibles'), tile);
+                    });
                     return tile;
                 }
             });

--- a/mbtilesCreator.js
+++ b/mbtilesCreator.js
@@ -69,25 +69,61 @@ function initCreatorMode() {
         }
     });
 
-    // Correction projection Yandex EPSG:3395 (même logique que dans index.html)
-    const L_YandexLayerCreator = L.TileLayer.extend({
-        getTileUrl: function (coords) {
-            const z = coords.z, x = coords.x;
-            const n = Math.pow(2, z);
-            const latN = Math.atan(Math.sinh(Math.PI * (1 - 2 * coords.y / n)));
-            const y3395 = Math.floor(n / 2 * (1 - _yMerc3395(latN) / Math.PI));
-            return L.Util.template(this._url, L.extend({}, this.options, { x, y: y3395, z }));
+    // Correction projection Yandex EPSG:3395 — reprojection EXACTE sur canvas
+    // (même logique que index.html/createBaseLayers : chaque tuile Leaflet
+    // assemble au pixel près les 1-2 tuiles Yandex couvrant sa plage de
+    // latitudes, au lieu de l'ancien décalage CSS approché qui laissait des
+    // jours horizontaux entre les rangées). _lat3857/_yMerc3395 : zoneDownloader.js.
+    const L_YandexLayerCreator = L.GridLayer.extend({
+        initialize: function (url, options) {
+            this._url = url;
+            L.GridLayer.prototype.initialize.call(this, options);
         },
         createTile: function (coords, done) {
-            const tile = L.TileLayer.prototype.createTile.call(this, coords, done);
+            const ts = this.getTileSize().y;
+            const tile = document.createElement('canvas');
+            tile.width = ts; tile.height = ts;
+
             const z = coords.z, n = Math.pow(2, z);
-            const tileSize = this.getTileSize().y;
-            const latN_3857 = Math.atan(Math.sinh(Math.PI * (1 - 2 * coords.y / n)));
-            const y3395 = Math.floor(n / 2 * (1 - _yMerc3395(latN_3857) / Math.PI));
-            const fracY = (n / 2 * (1 - _yMerc3395(latN_3857) / Math.PI)) - y3395;
-            const offsetPx = -(fracY * tileSize);
-            tile.style.marginTop = offsetPx + 'px';
-            tile.style.height = (tileSize + Math.ceil(-offsetPx) + 1) + 'px';
+            const py = (yTile) => n * ts / 2 * (1 - _yMerc3395(_lat3857(yTile, n)) / Math.PI);
+            const pyN = py(coords.y), pyS = py(coords.y + 1);
+            const H = pyS - pyN;
+
+            const ty0 = Math.max(0, Math.floor(pyN / ts));
+            const ty1 = Math.min(n - 1, Math.floor((pyS - 1e-9) / ts));
+            const srcs = [];
+            for (let ty = ty0; ty <= ty1; ty++)
+                srcs.push({ ty, url: L.Util.template(this._url, L.extend({}, this.options, { x: coords.x, y: ty, z })) });
+
+            const load = (url) => new Promise(resolve => {
+                const img = new Image();
+                img.crossOrigin = 'anonymous';
+                img.onload = () => resolve(img);
+                img.onerror = () => {
+                    const raw = new Image();
+                    raw.onload = () => resolve(raw);
+                    raw.onerror = () => resolve(null);
+                    raw.src = url;
+                };
+                img.src = url;
+            });
+
+            Promise.all(srcs.map(s => load(s.url))).then(imgs => {
+                const ctx = tile.getContext('2d');
+                let drawn = 0;
+                for (let i = 0; i < srcs.length; i++) {
+                    const img = imgs[i];
+                    if (!img) continue;
+                    const ty = srcs[i].ty;
+                    const srcTop = Math.max(pyN, ty * ts), srcBot = Math.min(pyS, (ty + 1) * ts);
+                    const sy = srcTop - ty * ts, sh = srcBot - srcTop;
+                    const dy = (srcTop - pyN) * ts / H, dh = sh * ts / H;
+                    const over = (i < srcs.length - 1) ? 1 : 0;
+                    ctx.drawImage(img, 0, sy, img.width, sh, 0, dy, ts, dh + over);
+                    drawn++;
+                }
+                done(drawn ? null : new Error('tuiles Yandex indisponibles'), tile);
+            });
             return tile;
         }
     });
@@ -344,9 +380,12 @@ class MbtilesJob {
         this.opfsDir = null;
 
         // Format de sortie des tuiles écrit dans les métadonnées MBTiles.
-        // - Multi-couches : composition obligatoire → ré-encodage (TILE_FORMAT).
-        // - Mono-couche : null = passthrough natif, détecté sur les octets reçus.
-        this.tileFormat = (layerConfig.layers.length > 1)
+        // - Multi-couches OU Yandex (reprojection toujours par canvas, même
+        //   mono-couche) : ré-encodage obligatoire (TILE_FORMAT).
+        // - Mono-couche sans Yandex : null = passthrough natif, détecté sur
+        //   les octets reçus.
+        const hasYandexLayer = layerConfig.layers.some(l => l.type === 'yandex');
+        this.tileFormat = (layerConfig.layers.length > 1 || hasYandexLayer)
             ? (TILE_FORMAT === 'image/jpeg' ? 'jpg' : 'png')
             : null;
 
@@ -495,38 +534,89 @@ class MbtilesJob {
         }
     }
 
-    // Construit les URLs pour une tuile (toutes les couches)
-    _tileUrls(tile) {
-        return this.layerConfig.layers.map(layer => {
-            if (layer.type === 'quadkey') {
-                const q = coordsToQuadKey(tile.x, tile.y, tile.z);
-                return layer.url.replace('{q}', q).replace('{s}', (tile.x + tile.y) % 4);
-            } else if (layer.type === 'yandex') {
-                const n = Math.pow(2, tile.z);
-                const latN = Math.atan(Math.sinh(Math.PI * (1 - 2 * tile.y / n)));
-                const y3395 = Math.floor(n / 2 * (1 - _yMerc3395(latN) / Math.PI));
-                return layer.url.replace('{z}', tile.z).replace('{x}', tile.x).replace('{y}', y3395);
-            } else {
-                return layer.url.replace('{z}', tile.z).replace('{x}', tile.x).replace('{y}', tile.y);
-            }
-        });
+    // Construit l'URL d'une couche NON-Yandex pour une tuile (Yandex a besoin
+    // de 1-2 URLs + un découpage en bandes — cf. _yandexBands ci-dessous, pas
+    // d'une simple URL unique).
+    _layerUrl(layer, tile) {
+        if (layer.type === 'quadkey') {
+            const q = coordsToQuadKey(tile.x, tile.y, tile.z);
+            return layer.url.replace('{q}', q).replace('{s}', (tile.x + tile.y) % 4);
+        }
+        return layer.url.replace('{z}', tile.z).replace('{x}', tile.x).replace('{y}', tile.y);
+    }
+
+    // Bandes source EPSG:3395 nécessaires pour reprojeter EXACTEMENT une tuile
+    // EPSG:3857 (tile.z/x/y) — même calcul que L_YandexLayerCreator (tuile
+    // Leaflet), exprimé directement en coordonnées pixel source→destination
+    // pour un dessin sur canvas 256×256. Sans ce découpage (ancien code :
+    // 1 seule tuile 3395 "la plus proche" étirée sur toute la tuile 256×256),
+    // les tuiles Yandex stockées dans le .mbtiles étaient visiblement
+    // décalées/mal alignées entre rangées voisines — aucune correction
+    // n'existait à la génération (contrairement à l'affichage Leaflet, qui
+    // avait au moins le décalage CSS approché).
+    _yandexBands(layer, tile) {
+        const ts = 256, z = tile.z, n = Math.pow(2, z);
+        const py = (yTile) => n * ts / 2 * (1 - _yMerc3395(_lat3857(yTile, n)) / Math.PI);
+        const pyN = py(tile.y), pyS = py(tile.y + 1);
+        const H = pyS - pyN;
+        const ty0 = Math.max(0, Math.floor(pyN / ts));
+        const ty1 = Math.min(n - 1, Math.floor((pyS - 1e-9) / ts));
+        const bands = [];
+        for (let ty = ty0; ty <= ty1; ty++) {
+            const srcTop = Math.max(pyN, ty * ts), srcBot = Math.min(pyS, (ty + 1) * ts);
+            bands.push({
+                url: layer.url.replace('{z}', z).replace('{x}', tile.x).replace('{y}', ty),
+                sy: srcTop - ty * ts, sh: srcBot - srcTop,
+                dy: (srcTop - pyN) * ts / H, dh: (srcBot - srcTop) * ts / H,
+            });
+        }
+        return bands;
+    }
+
+    // Dessine une couche Yandex reprojetée sur le canvas de la tuile (1-2
+    // bandes assemblées au pixel près) → true si au moins une bande a pu être
+    // dessinée. Chargement des sources en parallèle, dessin nord→sud ensuite.
+    async _drawYandexLayer(canvas, ctx, layer, tile) {
+        const bands = this._yandexBands(layer, tile);
+        const imgs = await Promise.all(bands.map(b => new Promise(resolve => {
+            const img = new Image();
+            img.crossOrigin = 'anonymous';
+            img.onload = () => resolve(img);
+            img.onerror = () => resolve(null);
+            img.src = b.url;
+        })));
+        let drawn = 0;
+        for (let i = 0; i < bands.length; i++) {
+            const img = imgs[i];
+            if (!img) continue;
+            const b = bands[i];
+            // +1 px de recouvrement (sauf dernière bande) : supprime le liseré
+            // d'anticrénelage aux frontières fractionnaires (la bande suivante,
+            // opaque, repeint par-dessus).
+            const over = (i < bands.length - 1) ? 1 : 0;
+            try { ctx.drawImage(img, 0, b.sy, img.width, b.sh, 0, b.dy, 256, b.dh + over); drawn++; }
+            catch { /* image cassée → bande ignorée, les autres continuent */ }
+        }
+        return drawn > 0;
     }
 
     // Récupère une tuile → retourne le blob à stocker (ou null si vide/échec).
     async _processTile(tile) {
-        const urls = this._tileUrls(tile);
+        const hasYandex = this.layerConfig.layers.some(l => l.type === 'yandex');
 
-        // --- Cas mono-couche : passthrough natif (AUCUNE recompression) ---
+        // --- Cas mono-couche SANS Yandex : passthrough natif (AUCUNE recompression) ---
         // On stocke l'octet pour octet ce que renvoie le serveur, dans son
         // format d'origine (JPEG/PNG/WebP). Évite la perte de génération
-        // d'un re-encodage canvas.toBlob() d'un JPEG en JPEG.
-        if (urls.length === 1) {
-            return this._fetchRawTile(urls[0]);
+        // d'un re-encodage canvas.toBlob() d'un JPEG en JPEG. Une couche Yandex
+        // DOIT toujours passer par le canvas : sa reprojection (1-2 bandes
+        // source) ne peut jamais être un simple octet-pour-octet.
+        if (this.layerConfig.layers.length === 1 && !hasYandex) {
+            return this._fetchRawTile(this._layerUrl(this.layerConfig.layers[0], tile));
         }
 
-        // --- Cas multi-couches : composition obligatoire sur canvas ---
-        // La fusion de plusieurs images impose un ré-encodage : il n'existe
-        // pas de "format natif" pour une tuile composite.
+        // --- Cas multi-couches ou reprojection Yandex : composition sur canvas ---
+        // La fusion de plusieurs images (ou la reprojection Yandex) impose un
+        // ré-encodage : il n'existe pas de "format natif" pour une tuile composite.
         const canvas = document.createElement('canvas');
         canvas.width = 256; canvas.height = 256;
         const ctx = canvas.getContext('2d');
@@ -537,8 +627,10 @@ class MbtilesJob {
             ctx.fillRect(0, 0, 256, 256);
         }
         let hasContent = false;
-        for (const url of urls) {
-            const ok = await this.fetchAndDrawLayer(url, canvas, ctx);
+        for (const layer of this.layerConfig.layers) {
+            const ok = layer.type === 'yandex'
+                ? await this._drawYandexLayer(canvas, ctx, layer, tile)
+                : await this.fetchAndDrawLayer(this._layerUrl(layer, tile), canvas, ctx);
             if (ok) hasContent = true;
         }
         if (!hasContent) return null;

--- a/zoneDownloader.js
+++ b/zoneDownloader.js
@@ -9,6 +9,12 @@ function _yMerc3395(latRad) {
     return Math.log(Math.tan(Math.PI / 4 + latRad / 2) *
         Math.pow((1 - _e_WGS84 * s) / (1 + _e_WGS84 * s), _e_WGS84 / 2));
 }
+// Latitude (rad) du bord nord d'une tuile EPSG:3857 (Web Mercator sphérique
+// standard, utilisé par Leaflet) — sert de point de départ à la reprojection
+// Yandex (3395), qui compare cette latitude à la même tuile en 3395.
+function _lat3857(yTile, n) {
+    return Math.atan(Math.sinh(Math.PI * (1 - 2 * yTile / n)));
+}
 // Inverse Mercator ellipsoïdal : de la valeur m (rad) vers la latitude (rad), itératif
 function _inverseMerc3395(m) {
     let lat = 2 * Math.atan(Math.exp(m)) - Math.PI / 2;


### PR DESCRIPTION
## Résumé

Porte sur Carroyage-JMT l'amélioration de reprojection Yandex déjà appliquée sur CadoTour (EPSG:3395 → EPSG:3857), pour l'affichage Leaflet **et** la génération de MBTiles.

Yandex sert ses tuiles en EPSG:3395 (Mercator ellipsoïdal WGS84) alors que Leaflet/le standard web utilise EPSG:3857 (Pseudo-Mercator sphérique). Les deux projections divergent avec la latitude. L'ancienne technique (décalage CSS `marginTop` + étirement de `height` sur une seule tuile 3395 « la plus proche ») laissait des jours horizontaux entre tuiles voisines et déformait légèrement l'image.

La nouvelle technique remplace `L.TileLayer.extend` par `L.GridLayer.extend` : chaque tuile Leaflet devient un `<canvas>` sur lequel sont assemblées, au pixel près, les 1-2 tuiles source EPSG:3395 couvrant exactement sa plage de latitudes (avec repli sans CORS si le chargement en `crossOrigin` échoue). Deux tuiles Leaflet voisines partagent ainsi mathématiquement la même frontière 3395, ce qui élimine tout jour visible.

- `zoneDownloader.js` : ajoute le helper partagé `_lat3857` (à côté de `_yMerc3395` déjà présent), utilisé par la génération MBTiles.
- `index.html` (`createBaseLayers()`) : `L_YandexLayer` réécrit en `L.GridLayer` avec reprojection par bandes sur canvas — utilisé pour la carte interactive et la carte de zone.
- `mbtilesCreator.js` :
  - `L_YandexLayerCreator` (aperçu de la carte dans l'outil MBTiles) : même réécriture.
  - Pipeline de génération MBTiles (`_processTile`) : n'avait auparavant **aucune** correction de projection Yandex (tuile 3395 la plus proche étirée telle quelle sur 256×256). Ajout de `_yandexBands()` (calcul des bandes source→destination) et `_drawYandexLayer()` (dessin sur le canvas de composition), branchés dans `_processTile`. Une couche Yandex mono-couche passe désormais systématiquement par le canvas (comme le multi-couches), la reprojection l'exigeant toujours — `tileFormat` mis à jour en conséquence.

## Plan de test

- [x] `node --check` sur `zoneDownloader.js` et `mbtilesCreator.js`
- [x] Test Playwright (réseau et Service Worker mockés/bloqués) : affichage Leaflet réel via le flux d'init normal (sélection du fond « Yandex Hybride (FR)» sur Moscou, zoom 10) → 72/72 tuiles canvas chargées sans jour ni erreur console
- [x] Test Playwright : appel direct de `MbtilesJob._processTile()`/`_yandexBands()` sur une tuile Yandex → 2 bandes calculées correctement, blob JPEG généré avec succès


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ec61DMAPoPici3ZXe5KGxr)_